### PR TITLE
Improve invide druid decision feedback #34

### DIFF
--- a/AncientReligions/events/ACR_druidic_caste_events.txt
+++ b/AncientReligions/events/ACR_druidic_caste_events.txt
@@ -43,17 +43,8 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
-				}		
+					character_event = { id = ancrel.0158 }
+				}
 			}
 			30 = {
 				create_character = {
@@ -70,17 +61,8 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
-				}			
+					character_event = { id = ancrel.0158 }
+				}
 			}
 			20 = {
 				create_character = {
@@ -97,17 +79,8 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
-				}			
+					character_event = { id = ancrel.0158 }
+				}
 			}
 			12 = {
 				create_character = {
@@ -124,17 +97,8 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
-				}			
+					character_event = { id = ancrel.0158 }
+				}
 			}
 			3 = {
 				create_character = {
@@ -151,17 +115,8 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
-				}			
+					character_event = { id = ancrel.0158 }
+				}
 			}
 		}
 	}
@@ -254,16 +209,7 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
+					character_event = { id = ancrel.0158 }
 				}		
 			}
 			30 = {
@@ -281,16 +227,7 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
+					character_event = { id = ancrel.0158 }
 				}			
 			}
 			20 = {
@@ -308,16 +245,7 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
+					character_event = { id = ancrel.0158 }
 				}			
 			}
 			12 = {
@@ -335,16 +263,7 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
+					character_event = { id = ancrel.0158 }
 				}			
 			}
 			3 = {
@@ -362,16 +281,7 @@ character_event = {
 					}
 				}
 				new_character = {
-					opinion = {
-						modifier = opinion_patron
-						who = ROOT
-						years = 20
-					}
-					reverse_opinion = {
-						modifier = opinion_new_courtier
-						who = ROOT
-						years = 5
-					}				
+					character_event = { id = ancrel.0158 }
 				}			
 			}
 		}
@@ -484,6 +394,101 @@ character_event = {
 			}
 			give_nickname = nick_the_wicked
 		}
+	}
+}
+
+# Ping new Druid to set correct scopes scope.
+# FROM is the liege
+character_event = {
+	id = ancrel.0158
+	hide_window = yes
+	
+	is_triggered_only = yes
+	
+	immediate = {
+		FROM = {
+			character_event = { id = ancrel.0159 }
+		}
+	}
+
+	option = {
+		name = OK
+	}
+}
+
+# Liege is notified that a Druid arrived at court
+# FROM is the druid
+character_event = {
+	id = ancrel.0159
+	desc = EVTDESCancrel.0159
+	picture = GFX_evt_viking_throneroom_oldgods
+	
+	is_triggered_only = yes
+	
+	show_from = yes
+	
+	immediate = {
+		FROM = { 
+			opinion = {
+				modifier = opinion_patron
+				who = ROOT
+				years = 20
+			}
+			reverse_opinion = {
+				modifier = opinion_new_courtier
+				who = ROOT
+				years = 5
+			}
+		}
+	}
+	
+	option = {
+		name = EVTOPTAancrel.0159
+
+		trigger = {
+			NOT = {
+				any_courtier = {
+					has_minor_title = title_court_druid
+				}
+			}
+		}
+		FROM = {
+			give_minor_title = title_court_druid
+		}
+	}
+	
+	option = {
+		name = EVTOPTBancrel.0159
+		
+		trigger = {
+			NOT = {
+				any_courtier = {
+					has_job_title = job_chancellor
+				}
+			}
+		}
+		FROM = {
+			give_job_title = job_chancellor
+		}
+	}
+	
+	option = {
+		name = EVTOPTCancrel.0159
+		
+		trigger = {
+			NOT = { 
+				any_courtier = {
+					has_job_title = job_spiritual
+				}
+			}
+		}
+		FROM = {
+			give_job_title = job_spiritual 
+		}
+	}
+	
+	option = {
+		name = EVTOPTDancrel.0159
 	}
 }
 

--- a/AncientReligions/localisation/ACR_druidic_caste.csv
+++ b/AncientReligions/localisation/ACR_druidic_caste.csv
@@ -21,6 +21,11 @@ EVTOPTAancrel.0155;Send for a master of law.;French;German;;Spanish;;;;;;;;;;;x
 EVTOPTBancrel.0155;Bring me a servant of the gods.;French;German;;Spanish;;;;;;;;;;;x
 EVTDESCancrel.0157;A Druid is expected to follow the Celtic Virtues of honor, loyalty, hospitality, honesty, justice and courage. Gossip is starting to spread about your wicked habits.;FRENCH;GERMAN;;SPANISH;;;;;;;;;;;;;;x
 EVTOPTAancrel.0157;May [Root.Religion.GetRandomGodName] have mercy on me.;FRENCH;GERMAN;;SPANISH;;;;;;;;;;;;;;x
+EVTDESCancrel.0159;The Druid presents [From.GetHerselfHimself] to you. In order to judge of [From.GetHerHis] talents, you request [From.GetHerHim] to show you the subject [From.GetSheHe] is most skillful at.;;;;;;;;;;;;;;;x
+EVTOPTAancrel.0159;[From.GetSheHeCap] shall be my new Court Druid !;;;;;;;;;;;;;;;x
+EVTOPTBancrel.0159;[From.GetSheHeCap] shall be my new [From.GetChancellorName] !;;;;;;;;;;;;;;;x
+EVTOPTCancrel.0159;[From.GetSheHeCap] shall be my new [From.GetLordSpiritualName] !;;;;;;;;;;;;;;;x
+EVTOPTDancrel.0159;I will settle this matter later.;;;;;;;;;;;;;;;x
 #;;;;;;;;;;;;;;x
 new_druid_in_court;New Druid in Court;French;German;;Spanish;;;;;;;;;;;x
 new_druid_in_court_desc;A Druid has just arrived in this lord's court.;French;German;;Spanish;;;;;;;;;;;x
@@ -28,6 +33,7 @@ title_court_druid;Court Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 title_court_druid_desc;Responsible for organising worship and sacrifices, divination, and judicial procedure in Celtic society, they are as essential to a ruler as his sword.;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 title_court_bard;Court Bard;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 title_court_bard_desc;Bards were those who sang the songs recalling the tribal warriors' deeds of bravery as well as the genealogies and family histories of the ruling strata among Celtic societies. The Celtic peoples maintain an intricate oral history committed to memory and transmitted by bards. Bards facilitated the memorization of such materials by the use of metre, rhyme and other formulaic poetic devices.;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+#;;;;;;;;;;;;;;x
 EVTNAMEancrel.0183;Coming of age;French;German;;Spanish;;;;;;;;;;;x
 EVTDESCancrel.0183;Today your child comes of age. [From.GetSheHeCap] will join the clan today as the Druids present [From.GetHerHim] to the gods. You can use this opportunity to plan [From.GetHerHis] future.;French;German;;Spanish;;;;;;;;;;;x
 EVTOPTAancrel.0183;[From.GetSheHeCap] will be a warrior;French;German;;Spanish;;;;;;;;;;;x


### PR DESCRIPTION
- Add a follow-up event where the druid actually presents himself (show_from = yes)
- Also allows to remove duplication of opinion modifiers setup
- Add event options to nominate as Chancellor/Seer/Court druid, if applicable