### PR TITLE
Bugfix/37 restore roman empire

### DIFF
--- a/AncientReligions/decisions/ACR_LoR_decisions.txt
+++ b/AncientReligions/decisions/ACR_LoR_decisions.txt
@@ -1,47 +1,4 @@
 decisions = {
-	restore_roman_empire = {
-		is_high_prio = yes
-		potential = {
-			has_dlc = "Legacy of Rome"
-			age = 16
-			prisoner = no
-			NOT = { trait = incapable }
-			NOT = { has_global_flag = rome_restored }
-			has_landed_title = e_byzantium
-			OR = {
-				religion_group = christian
-				religion_group = pagan_group
-			}
-		}
-		
-		allow = {
-			prestige = 3000
-
-			# The two capitals
-			completely_controls = d_latium
-			completely_controls = d_thrace
-
-			# Key positions in Roman Italia
-			completely_controls = d_ferrara
-			completely_controls = d_genoa
-			completely_controls = d_capua
-			completely_controls = d_apulia
-
-			# Key positions outside Roman Italia
-			completely_controls = d_venice
-			completely_controls = d_sicily
-			completely_controls = d_alexandria
-			completely_controls = d_athens
-			completely_controls = d_tunis
-		}
-		effect = {
-			set_global_flag = rome_restored
-			narrative_event = { id = ancrel.2220 tooltip = EVTTOOLTIPLoR.20 }
-		}
-		ai_will_do = {
-			factor = 1
-		}
-	}
 
 	recreate_roman_empire = {
 		is_high_prio = yes

--- a/AncientReligions/decisions/realm_decisions.txt
+++ b/AncientReligions/decisions/realm_decisions.txt
@@ -1,0 +1,2236 @@
+decisions = {
+
+	hold_a_epic_tournament  = {
+		is_high_prio = yes
+		potential = {
+			NOT = {
+				has_character_flag = epic_tournament
+				has_character_flag = do_not_disturb
+			}
+			OR = {
+				religion_group = christian
+				religion_group = jewish_group
+				religion_group = zoroastrian_group
+			}
+			independent = yes
+			NOT = { is_female = yes	}
+			OR = {
+				tier = king
+				tier = emperor 
+			}
+			location = {
+				owner = { character = ROOT }
+			}
+		}
+		allow = {
+			war = no
+			prisoner = no
+			in_command = no
+			NOT = { trait = in_hiding }
+			age = 16
+			prestige = 500
+			wealth = 200
+		}
+		effect = {
+			set_character_flag = epic_tournament
+			set_character_flag = do_not_disturb
+			clr_character_flag = tournament_has_ended
+			hidden_tooltip = { character_event = { id = 70999 days = 150 } } # Safety catch flag clearing
+			wealth = -200
+			prestige = 100
+			character_event = { id = 70033 tooltip = "tournament_invite" }
+			hidden_tooltip = {
+				character_event = { id = 70001 days = 60 } # Tournament start
+				clr_character_flag = tournament_has_ended
+				any_realm_character = {
+					limit = {
+						OR = {
+							is_feudal = yes
+							is_tribal = yes
+						}
+						NOT = { has_job_title = job_spiritual }
+						age = 16
+						NOT = { age = 50 }
+						NOT = { trait = incapable }
+						prisoner = no	
+						is_female = no
+					}
+					clr_character_flag = tournament_has_ended
+					character_event = { id = 70000 }
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = {
+					OR = {
+						wealth = 1000
+						scaled_wealth = 3.0
+					}
+				}
+			}
+		}
+	}
+	
+	buy_indulgence_for_sins = {
+		potential = {
+			religion = catholic
+			age = 16
+			demesne_size = 1
+			NOT = { has_character_flag = ask_for_indulgence }
+		}
+		allow = {
+			scaled_wealth = 1.0
+			wealth = 25
+			is_heretic = no
+		}
+		effect = {
+			set_character_flag = ask_for_indulgence
+			rightful_religious_head_scope = {
+				character_event = { id = 39250 days = 5 random = 12 tooltip = "indulgence_ask" }
+			}
+		}
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				OR = {
+					NOT = { scaled_wealth = 10.0 }
+					piety = 0
+				}
+			}
+		}
+	}
+
+	issue_declaration_of_repentance = {
+		potential = {
+			religion = catholic
+			age = 16
+			demesne_size = 1
+			NOT = { has_character_flag = ask_for_repentance }
+			rightful_religious_head_scope = {
+				ROOT = {
+					excommunicated_for = PREV
+				}
+			}
+		}
+		allow = {
+			scaled_wealth = 2.0
+			is_heretic = no
+		}
+		effect = {
+			set_character_flag = ask_for_repentance
+			rightful_religious_head_scope = {
+				character_event = { id = 39252 days = 5 random = 12 tooltip = "repentance_ask" }
+			}
+		}
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = {
+					scaled_wealth = 10.0
+				}
+			}
+		}
+	}
+	
+	demand_liege_title = {
+		is_high_prio = yes
+		potential = {
+			ai = no
+			NOT = { has_character_flag = requested_de_jure_title }
+			liege = {
+				NOT = { character = ROOT }
+			}
+			is_adult = yes
+			prisoner = no
+			is_playable = yes
+			tier = count
+			NOT = { trait = incapable }
+		}
+		allow = {
+			liege = {
+				opinion = {
+					who = ROOT
+					value = 25
+				}
+			}
+			liege = {
+				any_demesne_title = {
+					tier = duke
+					has_de_jure_pretension = ROOT
+					can_be_given_away = yes
+					lower_tier_than = PREV
+				}
+			}
+		}
+		effect = {
+			set_character_flag = requested_de_jure_title
+			liege = { letter_event = { id = 63041 days = 4 tooltip = "EVTTOOLTIP63041" } } # "vassal_request_events.txt"
+		}
+		ai_will_do = {
+			factor = 0 # The AI is limited to the similar event 63040
+		}
+	}
+	
+	sadaqah_saddka  = {
+		potential = {
+			ai = no
+			religion_group = muslim
+			age = 16
+			demesne_size = 1
+			NOT = { has_character_flag = voluntary_charity }
+			rightful_religious_head_scope = {	
+				NOT = {
+					character = ROOT
+				}
+				NOT = {
+					has_opinion_modifier = { who = ROOT modifier = opinion_sadaqah }
+				}
+			}
+		}
+		allow = {
+			scaled_wealth = 1.0
+			is_heretic = no
+		}
+		effect = {
+			set_character_flag = voluntary_charity
+			scaled_wealth = -0.25
+			piety = 25
+			rightful_religious_head_scope = {
+				character_event = { id = 31000 days = 5 random = 12 tooltip = "sadaqah_voluntary_charity" }
+			}
+		}
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				ai = yes
+				OR = {
+					NOT = { scaled_wealth = 10.0 }
+					piety = 0
+				}
+			}
+		}
+	}
+
+	hold_a_furusiyya  = {
+		is_high_prio = yes
+		potential = {
+			NOT = {
+				has_character_flag = epic_tournament_furusiyya
+			}
+			religion_group = muslim
+			independent = yes
+			NOT = { is_female = yes	}
+			OR = {
+				tier = king
+				tier = emperor 
+			}
+			location = {
+				owner = { character = ROOT }
+			}
+		}
+		allow = {
+			war = no
+			in_command = no
+			prisoner = no
+			NOT = { trait = in_hiding }
+			age = 16
+			prestige = 500
+			wealth = 200
+		}
+		effect = {
+			set_character_flag = epic_tournament_furusiyya
+			clr_character_flag = tournament_has_ended_furusiyya
+			hidden_tooltip = { character_event = { id = 88999 days = 150 } } # Safety catch flag clearing
+			wealth = -200
+			prestige = 100
+			decadence = -5
+			character_event = { id = 88283 tooltip = "furusiyya_invite" }
+			hidden_tooltip = {
+				character_event = { id = 88251 days = 60 } # Tournament start
+				clr_character_flag = tournament_has_ended_furusiyya
+				any_realm_character = {
+					limit = {
+						OR = {
+							is_feudal = yes
+							is_tribal = yes
+						}
+						NOT = { has_job_title = job_spiritual }
+						age = 16
+						NOT = { age = 50 }
+						NOT = { trait = incapable }
+						prisoner = no	
+						is_female = no
+					}
+					clr_character_flag = tournament_has_ended_furusiyya
+					character_event = { id = 88250 }
+				}
+				any_dynasty_member = {
+					limit = { 
+						ai = no
+						NOT = { character = ROOT }
+					}
+					character_event = { id = 88300 }
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = {
+					OR = {
+						wealth = 1000
+						scaled_wealth = 3.0
+					}
+				}
+			}
+		}
+	}
+	
+	restore_roman_empire = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "Legacy of Rome"
+			age = 16
+			prisoner = no
+			NOT = { trait = incapable }
+			NOT = { has_global_flag = rome_restored }
+			has_landed_title = e_byzantium
+			OR = {
+				religion_group = christian
+				religion_group = pagan_group
+			}
+		}
+		
+		allow = {
+			prestige = 3000
+
+			# The two capitals
+			completely_controls = d_latium
+			completely_controls = d_thrace
+
+			# Key positions in Roman Italia
+			completely_controls = d_ferrara
+			completely_controls = d_genoa
+			completely_controls = d_capua
+			completely_controls = d_apulia
+
+			# Key positions outside Roman Italia
+			completely_controls = d_venice
+			completely_controls = d_sicily
+			completely_controls = d_alexandria
+			completely_controls = d_athens
+			completely_controls = d_tunis
+		}
+		effect = {
+			set_global_flag = rome_restored
+			narrative_event = { id = ancrel.2220 tooltip = EVTTOOLTIPLoR.20 }
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	mend_great_schism = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "Legacy of Rome"
+			age = 16
+			prisoner = no
+			NOT = { trait = incapable }
+			OR = {
+				has_landed_title = e_byzantium
+				has_landed_title = e_roman_empire
+			}
+			OR = {
+				religion = orthodox
+				religion = paulician
+				religion = monothelite
+				religion = iconoclast
+			}
+			is_heretic = no
+			NOT = { has_global_flag = schism_mended }
+			k_papal_state = {
+				holder_scope = {
+					is_heretic = no # If the Pope (and thus Catholicism) is heretical, mending the schism is no longer possible
+				}
+			}
+		}
+		allow = {
+			piety = 2000
+			religion_authority = 0.9
+			completely_controls = c_byzantion
+			b_hagiasophia = {
+				holder_scope = {
+					OR = {
+						religion = orthodox
+						religion = paulician
+						religion = monothelite
+						religion = iconoclast
+					}
+					is_heretic = no
+				}
+			}
+			completely_controls = c_antiocheia
+			b_antiocheia = {
+				holder_scope = {
+					OR = {
+						religion = orthodox
+						religion = paulician
+						religion = monothelite
+						religion = iconoclast
+					}
+					is_heretic = no
+				}
+			}
+			completely_controls = c_jerusalem
+			b_jerusalem = {
+				holder_scope = {
+					OR = {
+						religion = orthodox
+						religion = paulician
+						religion = monothelite
+						religion = iconoclast
+					}
+					is_heretic = no
+				}
+			}
+			completely_controls = c_alexandria
+			b_alexandria = {
+				holder_scope = {
+					OR = {
+						religion = orthodox
+						religion = paulician
+						religion = monothelite
+						religion = iconoclast
+					}
+					is_heretic = no
+				}
+			}
+			completely_controls = c_roma
+			b_roma = {
+				holder_scope = {
+					OR = {
+						religion = orthodox
+						religion = paulician
+						religion = monothelite
+						religion = iconoclast
+					}
+					is_heretic = no
+				}
+			}
+		}
+		effect = {
+			narrative_event = { id = LoR.210 tooltip = EVTTOOLTIPLoR.210}
+			set_global_flag = schism_mended
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	claim_constantinople = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "Legacy of Rome"
+			NOT = { has_landed_title = c_byzantion }
+			has_landed_title = e_byzantium
+			any_realm_lord = { 
+				AND = {
+					ai = yes
+					has_landed_title = c_byzantion 
+				}
+			}
+		}
+		allow = {
+			NOT = { has_landed_title = c_byzantion }
+			any_realm_lord = { 
+				has_landed_title = c_byzantion 
+			}
+		}
+		effect = {
+			ROOT = {
+				c_byzantion = {
+					usurp_title_plus_barony_if_unlanded_and_vassals = PREV
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	make_rome_capital = {
+		is_high_prio = yes
+		potential = {
+			ai = no
+			has_dlc = "Legacy of Rome"
+			has_landed_title = e_roman_empire
+			capital_scope = {
+				NOT = { province_id = 333 }
+			}
+			any_realm_lord = { 
+				AND = {
+					ai = yes
+					has_landed_title = c_roma 
+				}
+			}
+			any_realm_lord = { 
+				AND = {
+					ai = yes
+					has_landed_title = b_tivoli
+				}
+			}
+		}
+		allow = {
+			has_landed_title = e_roman_empire
+			any_realm_lord = { has_landed_title = c_roma }
+		}
+		effect = {
+			custom_tooltip = {
+				text = rome_capital
+				hidden_tooltip = {
+					b_tivoli = { province_capital = yes }
+					ROOT = {
+						b_tivoli = {
+							usurp_title = PREV
+						}
+					}
+					#b_roma = { set_name = Lateran }
+					b_tivoli = { 
+						set_name = Rome 
+						ROOT = { capital = PREV }
+					}
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	petition_doge_for_tp = {
+		is_high_prio = yes
+		potential = {
+			is_merchant_republic = no
+			is_patrician = yes
+			liege = { is_merchant_republic = yes }
+			NOT = { has_character_flag = petition_doge_for_tp_taken }
+			OR = {
+				liege = {
+					any_vassal = {
+						is_patrician = yes
+						num_of_trade_post_diff = {
+							character = ROOT
+							value = 10
+						}
+					}
+				}
+				AND = {
+					NOT = { num_of_trade_posts = 1 }
+					liege = {
+						any_vassal = {
+							is_patrician = yes
+							num_of_trade_posts = 10
+						}
+					}
+				}
+			}
+		}
+		allow = {
+			liege = {
+				opinion = {
+					who = ROOT
+					value = 25
+				}
+			}
+		}
+		effect = {
+			set_character_flag = petition_doge_for_tp_taken
+			liege = {
+				letter_event = { id = REP.500 days = 5 tooltip = EVTTOOLTIP_REP_500 }
+			}
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	usurp_tp = {
+		is_high_prio = yes
+		potential = {
+			is_merchant_republic = yes
+			is_patrician = yes
+			NOT = { has_character_flag = usurp_tp_taken }
+			OR = {
+				any_vassal = {
+					is_patrician = yes
+					num_of_trade_post_diff = {
+						character = ROOT
+						value = 10
+					}
+				}
+				AND = {
+					NOT = { num_of_trade_posts = 1 }
+					any_vassal = {
+						is_patrician = yes
+						num_of_trade_posts = 10
+					}
+				}
+			}
+		}
+		allow = {
+			is_merchant_republic = yes
+		}
+		effect = {
+			set_character_flag = usurp_tp_taken
+			if = {
+				limit = {
+					num_of_trade_posts = 1
+					any_vassal = {
+						is_patrician = yes
+						num_of_trade_post_diff = {
+							character = ROOT
+							value = 10
+						}
+					}
+				}
+				random_vassal = {
+					limit = {
+						is_patrician = yes
+						num_of_trade_post_diff = {
+							character = ROOT
+							value = 10
+						}
+					}
+					set_character_flag = target_patrician_doge
+					letter_event = { id = REP.510 days = 5 tooltip = EVTTOOLTIP_REP_510 }
+				}
+			}
+			if = {
+				limit = {
+					NOT = { num_of_trade_posts = 1 }
+					any_vassal = {
+						is_patrician = yes
+						num_of_trade_posts = 10
+					}
+				}
+				random_vassal = {
+					limit = {
+						is_patrician = yes
+						num_of_trade_posts = 10
+					}
+					set_character_flag = target_patrician_doge
+					letter_event = { id = REP.510 days = 5 tooltip = EVTTOOLTIP_REP_510 }
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	organize_varangian_guard = {
+		is_high_prio = yes
+		potential = {
+			has_landed_title = e_byzantium
+			is_female = no
+			prisoner = no
+			age = 16
+			has_global_flag = viking_age_started
+			NOT = { has_global_flag = varangian_guard_founded }
+			any_playable_ruler = {
+				religion = norse_pagan
+				capital_scope = {
+					distance = {
+						where = 496	# Constantinople
+						value = 400	# Not too far away
+					}
+				}
+			}
+		}
+		allow = {
+			prestige = 300
+			wealth = 300
+		}
+		effect = {
+			set_global_flag = varangian_guard_founded
+			prestige = -300
+			wealth = -300
+			activate_title = { title = d_varangian_guard status = yes }
+			hidden_tooltip = {
+				narrative_event = { id = TOG.3100 }
+				create_character = {
+					random_traits = yes
+					religion = norse_pagan
+					culture = norse
+					dynasty = NONE
+					female = no
+					age = 34
+					trait = skilled_tactician
+				}
+				new_character = {
+					d_varangian_guard = {
+						grant_title = PREV
+					}
+					set_defacto_liege = ROOT
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	create_hungary = {
+		is_high_prio = yes
+		potential = {
+			has_landed_title = k_magyar
+			culture = hungarian
+			k_hungary = {
+				has_holder = no
+			}
+			k_magyar = {
+				is_vice_royalty = no
+			}
+		}
+		allow = {
+			war = no
+			completely_controls = d_pest
+			OR = {
+				completely_controls = d_transylvania
+				completely_controls = d_ungvar
+				completely_controls = d_nyitra
+			}
+		}
+		effect = {
+			set_global_flag = avar_khaganate_renamed
+			k_hungary = {
+				reset_coa = THIS
+			}
+			if = {
+				limit = { has_nickname = no }
+				give_nickname = nick_the_great
+			}
+			spawn_unit = {
+				province = 522 # Pest
+				owner = ROOT
+				match_character = ROOT
+				match_mult = 1.0
+				attrition = 0.5
+			}
+			spawn_unit = {
+				province = 522 # Pest
+				owner = ROOT
+				match_character = ROOT
+				match_mult = 0.5
+				attrition = 0.5
+			}
+			spawn_unit = {
+				province = 522 # Pest
+				owner = ROOT
+				match_character = ROOT
+				match_mult = 0.33
+				attrition = 0.5
+			}
+			custom_tooltip = {
+				text = EVTOPTA62910_CUSTOM
+			}
+			prestige = 1000
+			wealth = 1000
+			narrative_event = { id = 62910 tooltip = EVTTOOLTIP62910 }
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	become_saoshyant = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "The Old Gods"
+			religion_group = zoroastrian_group
+			NOT = { has_global_flag = saoshyant_appears }
+		}
+		allow = {
+			has_landed_title = e_persia	
+			completely_controls = d_fars
+			completely_controls = d_khiva
+			completely_controls = d_merv
+			completely_controls = d_esfahan
+			completely_controls = d_hamadan
+			completely_controls = d_mazandaran
+			completely_controls = d_kermanshah
+			completely_controls = d_tigris
+			completely_controls = d_basra
+			completely_controls = d_baghdad
+			completely_controls = d_mosul
+			completely_controls = d_jazira			
+			completely_controls = d_kerman
+			completely_controls = d_khorasan
+			completely_controls = d_tabriz
+			completely_controls = d_azerbaijan
+			completely_controls = d_baluchistan
+			completely_controls = d_sistan
+			completely_controls = d_kabul
+			completely_controls = d_zabulistan
+			completely_controls = d_samarkand
+			completely_controls = d_dihistan
+			piety = 1500
+		}
+		effect = {
+			hidden_tooltip = {
+				narrative_event = { id = TOG.6000 }
+			}
+			set_global_flag = saoshyant_appears
+			give_nickname = nick_the_saoshyant
+			add_trait = saoshyant
+			prestige = 500
+			piety = 500
+			
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	create_leon = {
+		is_high_prio = yes
+		potential = {
+			has_landed_title = k_asturias
+			k_leon = {
+				has_holder = no
+			}
+			k_asturias = {
+				is_vice_royalty = no
+			}
+		}
+		allow = {
+			war = no
+			capital_scope = {
+				province_id = 190 # Leon
+			}
+			completely_controls = d_leon
+			completely_controls = d_asturias
+		}
+		effect = {
+			narrative_event = { id = 62920 tooltip = EVTTOOLTIP62920 }
+			if = {
+				limit = { has_nickname = no }
+				give_nickname = nick_the_great
+			}
+			prestige = 500
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	restore_priesthood = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "The Old Gods"
+			religion_group = zoroastrian_group
+			NOT = { has_global_flag = zoroastrian_priesthood_founded }
+		}
+		allow = {
+			has_landed_title = e_persia
+			piety = 300
+		}
+		effect = {
+			set_global_flag = zoroastrian_priesthood_founded
+			piety = -300
+			activate_title = { title = d_zoroastrian status = yes }
+			hidden_tooltip = {
+				create_random_priest = {
+					random_traits = yes
+					religion = zoroastrian
+					culture = persian
+					dynasty = random
+					female = no
+					age = 41
+				}
+				new_character = {
+					d_zoroastrian = {
+						grant_title = PREV
+					}
+					narrative_event = { id = TOG.6004 days = 2 }
+				}
+			}
+			d_zoroastrian = {
+				holder_scope = {
+					e_persia = {
+						holder_scope = {
+							set_defacto_vassal = PREVPREV
+						}
+					}
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	build_third_temple = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "Sons of Abraham"
+			religion_group = jewish_group
+			NOT = { has_global_flag = third_temple_built }
+			NOT = { has_global_flag = building_third_temple }
+		}
+		allow = {
+			completely_controls = c_jerusalem
+			774 = {
+				religion = ROOT
+			}
+			wealth = 1500
+			piety = 1500
+		}
+		effect = {
+			hidden_tooltip = {
+				character_event = { id = SoA.100 }
+				774 = {	province_event = { id = SoA.10199 days = 1460 random = 50 }	}
+			}
+			set_global_flag = building_third_temple
+			wealth = -1500
+			prestige = 500
+			piety = 500
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	restore_high_priesthood = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "Sons of Abraham"
+			religion = jewish
+			has_landed_title = k_israel
+			has_global_flag = third_temple_built
+			NOT = { has_global_flag = jewish_priesthood_founded }
+		}
+		allow = {
+			completely_controls = c_jerusalem
+			774 = {
+				religion = jewish
+			}
+			piety = 1000
+		}
+		effect = {
+			set_global_flag = jewish_priesthood_founded
+			activate_title = { title = d_jewish status = yes }
+			hidden_tooltip = {
+				create_random_priest = {
+					random_traits = yes
+					religion = ROOT
+					culture = ROOT
+					dynasty = random
+					female = no
+					age = 41
+				}
+				new_character = {
+					d_jewish = {
+						grant_title = PREV
+					}
+					narrative_event = { id = SoA.550 }
+				}
+			}
+			d_jewish = {
+				holder_scope = {
+					k_israel = {
+						holder_scope = {
+							set_defacto_vassal = PREVPREV
+						}
+					}
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	create_israel = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "Sons of Abraham"
+			religion_group = jewish_group
+			k_israel = {
+				has_holder = no
+			}
+		}
+		allow = {
+			completely_controls = d_jerusalem
+			completely_controls = d_ascalon
+			completely_controls = d_galilee
+			completely_controls = d_oultrejourdain
+			774 = {
+				religion = ROOT
+			}
+			piety = 500
+			prestige = 500
+		}
+		effect = {
+			narrative_event = { id = SoA.102 tooltip = EVTTOOLTIP_SoA_102 }
+			prestige = 1000
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	welcome_jews = {
+		potential = {
+			has_dlc = "Sons of Abraham"
+			NOT = { 
+				religion_group = jewish_group 
+				has_character_modifier = expelled_jews_timer
+			}
+			has_character_modifier = expelled_jewish
+			primary_title = { higher_tier_than = DUKE }
+		}
+		allow = {
+		}
+		effect = {
+			remove_character_modifier = expelled_jewish
+			custom_tooltip = {
+				text = jews_are_welcome
+			}
+			hidden_tooltip = {
+				character_event = { id = SoA.106 }
+			}
+		}
+		ai_will_do = {
+			factor = 1
+			
+			modifier = {
+				factor = 0.1 # Less likely to do it
+			}
+			modifier = {
+				factor = 0
+				trait = zealous
+			}
+		}
+	}
+	
+	expel_jews = {
+		potential = {
+			has_dlc = "Sons of Abraham"
+			OR = {
+				religion_group = christian
+				religion_group = muslim
+				religion_group = zoroastrian_group
+			}	
+			NOT = { 
+				religion_group = jewish_group
+				has_character_modifier = expelled_jewish
+				trait = incapable
+				any_realm_province = { religion_group = jewish_group }
+			}
+			independent = yes
+			is_playable = yes
+			age = 16
+			prisoner = no
+		}
+		allow = {
+		}
+		effect = {
+			if = {
+				limit = { has_character_modifier = borrowed_from_jews }
+				remove_character_modifier = borrowed_from_jews
+			}
+			add_character_modifier = {
+				name = expelled_jewish
+				duration = -1
+				inherit = yes
+			}
+			custom_tooltip = {
+				text = jews_are_expelled
+			}
+			hidden_tooltip = {
+				character_event = { id = SoA.105 }
+				add_character_modifier = {
+					name = expelled_jews_timer
+					duration = 7300
+					hidden = yes
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 1
+			
+			modifier = {
+				factor = 0.001 # Less likely to do it
+			}
+			modifier = {
+				factor = 0
+				any_courtier = {
+					religion_group = jewish_group
+					reverse_opinion = { who = ROOT value = 20 }
+				}
+			}
+			modifier = {
+				factor = 0
+				any_spouse = {
+					religion_group = jewish_group
+				}
+			}
+			modifier = {
+				factor = 0
+				any_child = {
+					religion_group = jewish_group
+				}
+			}
+			modifier = {
+				factor = 0
+				trait = kind
+			}
+			modifier = {
+				factor = 1.2
+				trait = zealous
+				trait = arbitrary
+			}
+			modifier = {
+				factor = 1.2
+				has_character_modifier = borrowed_from_jews
+				trait = greedy
+			}
+		}
+	}
+	
+	embrace_mutazila = {
+		potential = {
+			has_dlc = "Sons of Abraham"
+			religion = sunni
+			NOT = { 
+				OR = {
+					trait = mutazilite
+					trait = ashari
+				}
+			}
+			is_ruler = yes
+			age = 16
+			prisoner = no
+		}
+		
+		allow = {
+			piety = 50
+		}
+		
+		effect = {
+			add_trait = mutazilite
+			character_event = { id = SoA.600 tooltip = EVTTOOLTIP_SoA_600 }
+		}
+		
+		revoke_allowed = {
+			always = no
+		}
+		
+		ai_will_do = {
+			factor = 1
+			
+			modifier = {
+				factor = 0
+				trait = zealous
+			}
+			modifier = {
+				factor = 1.2
+				trait = cynical
+			}
+			modifier = {
+				factor = 1.2
+				liege = { trait = mutazilite }
+			}
+			modifier = {
+				factor = 0.005 # Slow it down
+			}
+		}
+	}
+	embrace_ashari = {
+		potential = {	
+			has_dlc = "Sons of Abraham"
+			religion = sunni
+			NOT = { 
+				OR = {
+					trait = mutazilite
+					trait = ashari
+				}
+			}
+			is_ruler = yes
+			age = 16
+			prisoner = no
+		}
+		
+		allow = {
+			piety = 50
+		}
+		
+		effect = {
+			add_trait = ashari
+			character_event = { id = SoA.601 tooltip = EVTTOOLTIP_SoA_601 }
+		}
+		
+		revoke_allowed = {
+			always = no
+		}
+		
+		ai_will_do = {
+			factor = 1
+			
+			modifier = {
+				factor = 0
+				trait = cynical
+			}
+			modifier = {
+				factor = 1.2
+				trait = zealous
+			}
+			modifier = {
+				factor = 1.2
+				liege = { trait = ashari }
+			}
+			modifier = {
+				factor = 1.2
+				decadence = 40
+			}
+			modifier = {
+				factor = 1.2
+				decadence = 60
+			}
+			modifier = {
+				factor = 1.2
+				decadence = 80
+			}
+			modifier = {
+				factor = 0.005 # Slow it down
+			}
+		}
+	}
+	
+	become_samrat_chakravartin = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "Rajas of India"
+			is_playable = yes
+			is_feudal = yes
+			religion_group = indian_group
+			primary_title = {
+				OR = {
+					title = e_rajastan
+					title = e_bengal
+					title = e_deccan
+					AND = {
+						tier = KING
+						OR = {
+							empire = { title = e_rajastan }
+							empire = { title = e_bengal }
+							empire = { title = e_deccan }
+						}
+					}
+				}
+			}
+			e_india = {
+				has_holder = no
+			}
+		}
+		allow = {
+			is_adult = yes
+			prisoner = no
+			NOT = {	trait = incapable }
+			war = no
+			prestige = 1000
+			wealth = 500
+			OR = {
+				has_landed_title = e_rajastan
+				e_rajastan = { has_holder = no }
+			}
+			OR = {
+				has_landed_title = e_bengal
+				e_bengal = { has_holder = no }
+			}
+			OR = {
+				has_landed_title = e_deccan
+				e_deccan = { has_holder = no }
+			}
+			completely_controls = k_sindh
+			completely_controls = k_punjab
+			completely_controls = k_delhi
+			completely_controls = k_rajputana
+			completely_controls = k_gujarat
+			completely_controls = k_malwa
+			completely_controls = k_kosala
+			completely_controls = k_bihar
+			completely_controls = k_bengal
+			completely_controls = k_kamarupa
+			completely_controls = k_orissa
+			completely_controls = k_gondwana
+			completely_controls = k_maharastra
+			completely_controls = k_telingana
+			completely_controls = k_karnata
+			completely_controls = k_andhra
+			completely_controls = k_tamilakam
+			completely_controls = k_lanka
+		}
+		effect = {
+			wealth = -500
+			prestige = 500
+			activate_title = { title = e_india status = yes }
+			hidden_tooltip = {
+				k_sindh = { de_jure_liege = e_india }
+				k_punjab = { de_jure_liege = e_india }
+				k_delhi = { de_jure_liege = e_india }
+				k_rajputana = { de_jure_liege = e_india }
+				k_gujarat = { de_jure_liege = e_india }
+				k_malwa = { de_jure_liege = e_india }
+				k_kosala = { de_jure_liege = e_india }
+				k_bihar = { de_jure_liege = e_india }
+				k_bengal = { de_jure_liege = e_india }
+				k_kamarupa = { de_jure_liege = e_india }
+				k_gondwana = { de_jure_liege = e_india }
+				k_maharastra = { de_jure_liege = e_india }
+				k_telingana = { de_jure_liege = e_india }
+				k_karnata = { de_jure_liege = e_india }
+				k_andhra = { de_jure_liege = e_india }
+				k_tamilakam = { de_jure_liege = e_india }
+				k_lanka = { de_jure_liege = e_india }
+				k_orissa = { de_jure_liege = e_india }
+				if = {
+					limit = { has_landed_title = e_rajastan } # In case of titles outside India having been assimilated de jure already
+					e_rajastan = {
+						any_direct_de_jure_vassal_title = {
+							de_jure_liege = e_india
+						}
+					}
+				}
+				if = {
+					limit = { has_landed_title = e_bengal }
+					e_bengal = {
+						any_direct_de_jure_vassal_title = {
+							de_jure_liege = e_india
+						}
+					}
+				}
+				if = {
+					limit = { has_landed_title = e_deccan }
+					e_deccan = {
+						any_direct_de_jure_vassal_title = {
+							de_jure_liege = e_india
+						}
+					}
+				}
+			}
+			primary_title = {
+				e_india = {
+					grant_title = ROOT
+					copy_title_laws = PREV
+					copy_title_history = PREV
+				}
+			}
+			hidden_tooltip = { e_india = { make_primary_title = yes } }
+			if = {
+				limit = {
+					OR = {
+						has_landed_title = e_rajastan
+						e_rajastan = { has_holder = no }
+					}
+				}
+				e_rajastan = { destroy_landed_title = THIS }
+				activate_title = { title = e_rajastan status = no }
+			}
+			if = {
+				limit = {
+					OR = {
+						has_landed_title = e_bengal
+						e_bengal = { has_holder = no }
+					}
+				}
+				e_bengal = { destroy_landed_title = THIS }
+				activate_title = { title = e_bengal status = no }
+			}
+			if = {
+				limit = {
+					OR = {
+						has_landed_title = e_deccan
+						e_deccan = { has_holder = no }
+					}
+				}
+				e_deccan = { destroy_landed_title = THIS }
+				activate_title = { title = e_deccan status = no }
+			}
+			if = {
+				limit = { has_nickname = no }
+				give_nickname = nick_the_magnificent
+			}
+			set_character_flag = achievement_my_very_own_subcontinent
+			chronicle = {
+				entry = CHRONICLE_UNITED_INDIA
+				picture = GFX_evt_throne_room
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+
+	form_the_hre = {
+		is_high_prio = yes
+		potential = {
+			has_global_flag = charlemagne_hre
+			is_playable = yes
+			independent = yes
+			OR = {
+				religion = catholic
+				religion = fraticelli
+			}
+			OR = {
+				culture = german
+				culture = dutch
+			}
+			e_hre = {
+				has_holder = no
+			}
+			e_france = {
+				has_holder = no
+			}
+		}
+		allow = {
+			is_adult = yes
+			prisoner = no
+			NOT = { trait = incapable }
+			prestige = 1000
+			realm_size = 180
+			has_landed_title = k_germany
+			any_demesne_title = {
+				tier = KING
+				NOT = {
+					title = k_germany
+				}
+			}
+			scaled_wealth = 2
+		}
+		effect = {
+			scaled_wealth = -2
+			if = {
+				limit = { has_nickname = no }
+				give_nickname = nick_the_great
+			}
+			primary_title = {
+				e_hre = {
+					grant_title = ROOT
+					copy_title_laws = PREV
+					add_law = succ_feudal_elective
+				}
+			}
+			any_demesne_title = {
+				limit = {
+					tier = KING
+					NOT = {
+						title = k_germany
+					}
+				}
+				destroy_landed_title = THIS
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+
+	form_the_hre_early = {
+		is_high_prio = yes
+		potential = {
+			NOT = { has_global_flag = charlemagne_hre }
+			NOT = { has_global_flag = rome_restored }
+			is_playable = yes
+			independent = yes
+			OR = {
+				religion = catholic
+				religion = fraticelli
+			}
+			NOT = { has_landed_title = e_byzantium }
+		}
+		allow = {
+			is_adult = yes
+			prisoner = no
+			NOT = { trait = incapable }
+			prestige = 1000
+			realm_size = 220
+			custom_tooltip = {
+				text = form_the_hre_early_tooltip_1
+				hidden_tooltip = {
+					OR = {
+						has_landed_title = k_italy
+						has_landed_title = e_italy
+					}
+				}
+			}
+			custom_tooltip = {
+				text = form_the_hre_early_tooltip_2
+				hidden_tooltip = {
+					any_demesne_title = {
+						OR = {
+							title = e_france
+							title = e_germany
+							title = e_britannia
+							title = e_spain
+							AND = {
+								tier = KING
+								NOT = {	title = k_italy	}
+								OR = {
+									empire = { title = e_france }
+									empire = { title = e_germany }
+									empire = { title = e_britannia }
+									empire = { title = e_spain }
+								}
+							}
+						}
+					}
+				}
+			}
+			custom_tooltip = {
+				text = form_the_hre_early_tooltip_3
+				hidden_tooltip = {
+					OR = {
+						has_landed_title = e_italy
+						e_italy = {	has_holder = no	}
+						e_italy = { holder_scope = { NOT = { religion_group = christian } } }
+					}
+					OR = {
+						has_landed_title = e_germany
+						e_germany = {	has_holder = no	}
+						e_germany = { holder_scope = { NOT = { religion_group = christian } } }
+					}
+					OR = {
+						has_landed_title = e_france
+						e_france = { has_holder = no	}
+						e_france = { holder_scope = { NOT = { religion_group = christian } } }
+					}
+					OR = {
+						has_landed_title = e_spain
+						e_spain = {	has_holder = no	}
+						e_spain = { holder_scope = { NOT = { religion_group = christian } } }
+					}
+					OR = {
+						has_landed_title = e_britannia
+						e_britannia = {	has_holder = no	}
+						e_britannia = { holder_scope = { NOT = { religion_group = christian } } }
+					}
+				}
+			}
+			religion_head = {
+				opinion = { who = ROOT value = 100 }
+			}
+			scaled_wealth = 2
+		}
+		effect = {
+			set_global_flag = charlemagne_hre
+			activate_title = { title = e_hre status = yes }
+			scaled_wealth = -2
+			if = {
+				limit = { has_nickname = no }
+				give_nickname = nick_the_great
+			}
+			any_demesne_title = {
+				limit = { tier = KING }
+				de_jure_liege = e_hre
+			}
+			hidden_tooltip = {
+				primary_title = {
+					if = {
+						limit = { tier = EMPEROR }
+						any_direct_de_jure_vassal_title = {
+							de_jure_liege = e_hre
+						}
+					}
+				}
+			}
+			primary_title = {
+				e_hre = {
+					grant_title = ROOT
+					copy_title_laws = PREV
+					set_coa = PREV
+				}
+			}
+			any_demesne_title = {
+				limit = {
+					tier = EMPEROR
+					NOT = { title = e_hre }
+				}
+				destroy_landed_title = THIS
+				hidden_tooltip = { activate_title = { title = THIS status = no } }
+			}
+#			any_demesne_title = {
+#				limit = { tier = KING }
+#				destroy_landed_title = THIS
+#			}
+			# Give lands to the Pope
+			if = {
+				limit = {
+					any_realm_title = {
+						title = c_roma
+						holder_scope = {
+							OR = {
+								ai = yes
+								any_demesne_title = {
+									tier = COUNT
+									NOT = { title = c_roma }
+								}
+							}
+						}
+					}
+				}
+				c_roma = {
+					ROOT = {
+						religion_head = {
+							grant_title = PREVPREV
+						}
+					}
+				}
+			}
+			if = {
+				limit = {
+					any_realm_title = {
+						title = c_ravenna
+						holder_scope = {
+							OR = {
+								ai = yes
+								any_demesne_title = {
+									tier = COUNT
+									NOT = { title = c_ravenna }
+								}
+							}
+						}
+					}
+				}
+				c_ravenna = {
+					ROOT = {
+						religion_head = {
+							grant_title = PREVPREV
+						}
+					}
+				}
+			}
+			if = {
+				limit = {
+					any_realm_title = {
+						title = c_ferrara
+						holder_scope = {
+							OR = {
+								ai = yes
+								any_demesne_title = {
+									tier = COUNT
+									NOT = { title = c_ferrara }
+								}
+							}
+						}
+					}
+				}
+				c_ferrara = {
+					ROOT = {
+						religion_head = {
+							grant_title = PREVPREV
+						}
+					}
+				}
+			}
+			if = {
+				limit = {
+					any_realm_title = {
+						title = c_urbino
+						holder_scope = {
+							OR = {
+								ai = yes
+								any_demesne_title = {
+									tier = COUNT
+									NOT = { title = c_urbino }
+								}
+							}
+						}
+					}
+				}
+				c_urbino = {
+					ROOT = {
+						religion_head = {
+							grant_title = PREVPREV
+						}
+					}
+				}
+			}
+			if = {
+				limit = {
+					any_realm_title = {
+						title = c_spoleto
+						holder_scope = {
+							OR = {
+								ai = yes
+								any_demesne_title = {
+									tier = COUNT
+									NOT = { title = c_spoleto }
+								}
+							}
+						}
+					}
+				}
+				c_spoleto = {
+					ROOT = {
+						religion_head = {
+							grant_title = PREVPREV
+						}
+					}
+				}
+			}
+			e_byzantium = {
+				holder_scope = {
+					opinion = {
+						who = ROOT
+						modifier = opinion_unhappy
+						months = 1200
+					}
+					hidden_tooltip = {
+						k_papal_state = {
+							holder_scope = {
+								reverse_opinion = {
+									who = PREVPREV
+									modifier = opinion_unhappy
+									months = 1200
+								}
+							}
+						}
+					}
+				}
+			}
+			if = {
+				limit = {
+					OR = {
+						NOT = {	has_character_flag = is_charlemagne }
+						has_character_flag = charlemagne_coronation
+					}
+				}
+				hidden_tooltip = { narrative_event = { id = CM.510 } }        # Spread the news
+			}
+			if = {
+				limit = {
+					has_character_flag = is_charlemagne
+					NOT = { has_character_flag = charlemagne_coronation }
+				}
+				hidden_tooltip = { narrative_event = { id = CM.1500 } }        # Charlemagne coronation
+			}
+			set_character_flag = achievement_holy_and_roman
+			chronicle = {
+				entry = CHRONICLE_FOUNDED_HRE
+				picture = GFX_evt_coronation
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	form_new_kingdom = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "Charlemagne"
+			is_playable = yes
+			tier = DUKE
+			NOT = { tier = KING }
+			OR = {
+				ai = no
+				AND = {
+					trait = proud
+					prestige = 5000
+				}
+				AND = {
+					trait = ambitious
+					prestige = 5000
+				}
+				prestige = 15000
+			}
+		}
+		allow = {
+			is_adult = yes
+			prisoner = no
+			NOT = { trait = incapable }
+			independent = yes
+			prestige = 1000
+			OR = {
+				realm_size = 35
+				custom_tooltip = {
+					text = form_new_kingdom_requirement_tooltip
+					hidden_tooltip = {
+						any_demesne_title = {
+							count = 3
+							tier = DUKE
+						}
+					}
+				}
+			}
+			wealth = 300
+		}
+		effect = {
+			primary_title = {
+				create_title = {
+					tier = KING
+					landless = no
+					temporary = no
+					custom_created = yes
+					culture = ROOT
+					holder = ROOT
+					base_title = THIS
+					copy_title_laws = yes
+				}
+
+				hidden_tooltip = {
+					empire = {
+						ROOT = {
+							primary_title = {
+								de_jure_liege = PREVPREV
+							}
+						}
+					}
+
+					ROOT = {
+						primary_title = {
+							holder_scope = {
+								any_title_under = {
+									limit = {
+										tier = DUKE
+										kingdom = {
+											has_holder = no
+										}
+									}
+									de_jure_liege = PREVPREV
+								}
+								any_title_under = {
+									limit = {
+										tier = COUNT
+										location = {
+											duchy = {
+												kingdom = {
+													has_holder = no
+												}
+												
+												NOT = { de_jure_liege_or_above = PREVPREVPREVPREV }
+												ROOT = {
+													completely_controls = PREV
+												}
+											}
+										}
+									}
+									location = {
+										duchy = {
+											de_jure_liege = PREVPREVPREVPREV
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+
+			}
+			wealth = -300
+			custom_tooltip = { text = form_new_kingdom_tooltip }
+			chronicle = {
+				entry = CHRONICLE_FOUNDED_NEW_KINGDOM_OR_EMPIRE
+				portrait = [Root.GetID]
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+
+	form_new_empire = {
+		is_high_prio = yes
+		potential = {
+			has_dlc = "Charlemagne"
+			is_playable = yes
+			tier = KING
+			NOT = { tier = EMPEROR }
+			OR = {
+				ai = no
+				AND = {
+					trait = proud
+					prestige = 40000
+				}
+				AND = {
+					trait = ambitious
+					prestige = 40000
+				}
+				prestige = 120000
+			}
+		}
+		allow = {
+			is_adult = yes
+			prisoner = no
+			NOT = { trait = incapable }
+			independent = yes
+			prestige = 8000
+			OR = {
+				realm_size = 180
+				custom_tooltip = {
+					text = form_new_empire_requirement_tooltip
+					hidden_tooltip = {
+						any_demesne_title = {
+							count = 3
+							tier = KING
+						}
+					}
+				}
+			}
+			wealth = 1000
+		}
+		effect = {
+			primary_title = {
+				create_title = {
+					tier = EMPEROR
+					landless = no
+					temporary = no
+					custom_created = yes
+					culture = ROOT
+					holder = ROOT
+					base_title = THIS
+					copy_title_laws = yes
+				}
+
+				hidden_tooltip = {
+					ROOT = {
+						primary_title = {
+							holder_scope = {
+								any_title_under = {
+									limit = {
+										tier = KING
+										empire = {
+											has_holder = no
+										}
+									}
+									de_jure_liege = PREVPREV
+								}
+								any_title_under = {
+									limit = {
+										tier = DUKE
+										location = {
+											kingdom = {
+												empire = {
+													has_holder = no
+												}
+												
+												NOT = { de_jure_liege_or_above = PREVPREVPREVPREV }
+												ROOT = {
+													completely_controls = PREV
+												}
+											}
+										}
+									}
+									location = {
+										kingdom = {
+											de_jure_liege = PREVPREVPREVPREV
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			wealth = -1000
+			custom_tooltip = { text = form_new_empire_tooltip }
+			chronicle = {
+				entry = CHRONICLE_FOUNDED_NEW_KINGDOM_OR_EMPIRE
+				portrait = [Root.GetID]
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	adopt_feudalism = {
+		is_high_prio = yes
+		potential = {
+			is_tribal = yes
+			independent = yes
+		}
+		allow = {
+			capital_scope = {
+				is_tribal = yes
+				has_building = tb_hillfort_4
+			}
+			primary_title = { has_law = tribal_organization_4 }
+			custom_tooltip = { 
+				text = TT_NOT_UNREFORMED_PAGAN
+				hidden_tooltip = {
+					OR = {
+						NOT = { religion_group = pagan_group }
+						is_reformed_religion = yes
+					}
+				}
+			}
+		}
+		effect = {
+			custom_tooltip = {
+				text = adopt_feudalism_tooltip_1
+				hidden_tooltip = {
+					capital_scope = {
+						convert_to_castle = yes
+						refill_holding_levy = yes
+					}
+				}
+			}
+			set_character_flag = achievement_not_a_tribe
+			if = {
+				limit = {
+					ai = no
+				}
+				chronicle = {
+					entry = CHRONICLE_ADOPTED_FEUDALISM
+					picture = GFX_evt_castle_construction
+				}
+			}
+			hidden_tooltip = {
+				any_demesne_title = {
+					if = {
+						limit = {
+							is_crown_law_title = yes
+						}
+						add_law = crown_authority_0
+					}
+				}
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1 # On average ca 1 year before taken
+		}
+	}
+	
+	convert_to_castle = {
+		is_high_prio = yes
+		potential = {
+			OR = {
+				is_feudal = yes
+				AND = {
+					is_tribal = yes
+					liege = {
+						is_feudal = yes
+					}
+				}
+			}
+			any_demesne_title = { is_tribal = yes }
+		}
+		allow = {
+			any_demesne_title = {
+				is_tribal = yes
+				has_any_building = tb_hillfort_4
+			}
+		}
+		effect = {
+			hidden_tooltip = {
+				any_demesne_title = {
+					if = {
+						limit = {
+							is_tribal = yes
+							has_building = tb_hillfort_4
+						}
+						convert_to_castle = yes
+						refill_holding_levy = yes
+					}
+				}
+			}
+			custom_tooltip = {
+				text = adopt_feudalism_tooltip_2
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1 # On average ca 1 year before taken
+		}
+	}
+	
+	adopt_republicanism = {
+		is_high_prio = yes
+		potential = {
+			is_tribal = yes
+			independent = yes
+			is_female = no
+			OR = {
+				ai = yes
+				AND = {
+					capital_scope = { port = yes }
+					has_dlc = "The Republic"
+				}
+			}
+		}
+		allow = {
+			capital_scope = {
+				is_tribal = yes
+				has_building = tb_market_town_4
+			}
+			primary_title = { has_law = tribal_organization_4 }
+			custom_tooltip = { 
+				text = TT_NOT_UNREFORMED_PAGAN
+				hidden_tooltip = {
+					OR = {
+						NOT = { religion_group = pagan_group }
+						is_reformed_religion = yes
+					}
+				}
+			}
+		}
+		effect = {
+			hidden_tooltip = {
+				if = { # create duchy if holder does not have one
+					limit = {
+						NOT = { higher_tier_than = COUNT }
+					}
+					primary_title = {
+						create_title = {
+							tier = DUKE
+							landless = no
+							temporary = no
+							custom_created = yes
+							culture = ROOT
+							holder = ROOT
+							base_title = THIS
+						}
+					}
+				}
+				create_family_palace = yes
+				any_unique_dynasty_vassal = { # gives random vassals a family palace
+					count = 4
+					limit = {
+						is_female = no
+						OR = {
+							is_republic = yes
+							is_tribal = yes
+						}
+						prisoner = no
+						NOT = { trait = incapable }
+						is_adult = yes
+						NOT = { 
+							dynasty = none 
+						}
+					}
+					create_family_palace = yes
+				}
+			}
+			custom_tooltip = {
+				text = adopt_republicanism_tooltip_1
+				hidden_tooltip = {
+					capital_scope = {
+						convert_to_city = yes
+						refill_holding_levy = yes
+					}
+				}
+			}
+			set_character_flag = achievement_res_publica
+			if = {
+				limit = {
+					ai = no
+				}
+				chronicle = {
+					entry = CHRONICLE_FOUNDED_MERCHANT_REPUBLIC
+					picture = GFX_evt_busy_trading_dock_republic
+				}
+			}
+			hidden_tooltip = {
+				any_demesne_title = {
+					if = {
+						limit = {
+							is_crown_law_title = yes
+						}
+						add_law = crown_authority_0
+					}
+				}
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 0.5 # On average ca 1 year before taken
+			modifier = {
+				factor = 2.0
+				stewardship = 10
+			}
+			modifier = {
+				factor = 2.0
+				is_republic = yes
+			}
+		}
+	}
+	
+	convert_to_city = {
+		is_high_prio = yes
+		potential = {
+			OR = {
+				is_republic = yes
+				AND = {
+					is_tribal = yes
+					liege = {
+						is_republic = yes
+					}
+				}
+			}
+			any_demesne_title = { is_tribal = yes }
+		}
+		allow = {
+			any_demesne_title = {
+				is_tribal = yes
+				has_any_building = tb_market_town_4
+			}
+		}
+		effect = {
+			hidden_tooltip = {
+				any_demesne_title = {
+					if = {
+						limit = {
+							is_tribal = yes
+							has_building = tb_market_town_4
+						}
+						convert_to_city = yes
+						refill_holding_levy = yes
+					}
+				}
+			}
+			custom_tooltip = {
+				text = adopt_republicanism_tooltip_2
+			}
+		}
+		revoke_allowed = {
+			always = no
+		}
+		ai_will_do = {
+			factor = 1 # On average ca 1 year before taken
+		}
+	}
+}
+

--- a/AncientReligions/decisions/realm_decisions.txt
+++ b/AncientReligions/decisions/realm_decisions.txt
@@ -1,3 +1,5 @@
+# Audax Validator "!" Ignore_1001
+# Audax Validator "!" Ignore_1006
 decisions = {
 
 	hold_a_epic_tournament  = {


### PR DESCRIPTION
Override roman_events.txt to redefine restore_roman_empire decision.
Creating separate decision for Hellenics-only wouldn't be enough, as the follow up events of restore_roman_empire need to be overridden too.