### PR TITLE
Feature/#71 move celtic holy site

### DIFF
--- a/AncientReligions/common/landed_titles/ACR_holy_sites.txt
+++ b/AncientReligions/common/landed_titles/ACR_holy_sites.txt
@@ -12,7 +12,7 @@ b_bangor_fawr = {
 	holy_site = celtic_pagan
 	holy_site = celtic_pagan_reformed
 }
-b_citeaux = {
+b_autun = {
 	holy_site = celtic_pagan
 	holy_site = celtic_pagan_reformed
 }

--- a/AncientReligions/common/landed_titles/ACR_holy_sites.txt
+++ b/AncientReligions/common/landed_titles/ACR_holy_sites.txt
@@ -12,7 +12,7 @@ b_bangor_fawr = {
 	holy_site = celtic_pagan
 	holy_site = celtic_pagan_reformed
 }
-b_whithorn = {
+b_citeaux = {
 	holy_site = celtic_pagan
 	holy_site = celtic_pagan_reformed
 }


### PR DESCRIPTION
Change celtic holy site from Whithorn (in Galloway, Scotland) to Autun (in Dijon, France).